### PR TITLE
Fix Token Location Tracking over Newlines

### DIFF
--- a/src/utils/system/__tests__/lexer.spec.js
+++ b/src/utils/system/__tests__/lexer.spec.js
@@ -24,6 +24,30 @@ it('extracts tokens from input', () => {
   ]);
 });
 
+it('tracks newlines in locations', () => {
+  const lexer = createLexer({
+    word: [/[a-zA-Z]+/, s => s],
+    space: /\s+/
+  });
+
+  const iterator = lexer.run('hello there\n\nnice to  meet \n you');
+  const result = runIterator(iterator);
+
+  expect(result).toEqual([
+    { type: 'word', value: 'hello', ...loc(1, 1) },
+    { type: 'space', ...loc(1, 6) },
+    { type: 'word', value: 'there', ...loc(1, 7) },
+    { type: 'space', ...loc(1, 12) },
+    { type: 'word', value: 'nice', ...loc(3, 1) },
+    { type: 'space', ...loc(3, 5) },
+    { type: 'word', value: 'to', ...loc(3, 6) },
+    { type: 'space', ...loc(3, 8) },
+    { type: 'word', value: 'meet', ...loc(3, 10) },
+    { type: 'space', ...loc(3, 14) },
+    { type: 'word', value: 'you', ...loc(4, 2) },
+  ]);
+});
+
 it('selects the longest match', () => {
   const lexer = createLexer({
     let: 'let',

--- a/src/utils/system/lexer.ts
+++ b/src/utils/system/lexer.ts
@@ -175,13 +175,13 @@ const createLocationHandler = (): LocationHandler => {
 const advancedLocation = (prevLocation: Location, source: string): Location => {
   const segments = source.split(/\r\n|\r|\n/);
 
-  const numLines = segments.length - 1;
+  const numLines = segments.length;
   const lastLine = segments[segments.length - 1] ?? '';
 
   return {
-    line: prevLocation.line + numLines,
-    column: numLines <= 1
-      ? prevLocation.column + lastLine.length
-      : lastLine.length
+    line: prevLocation.line + numLines - 1,
+    column: numLines > 1
+      ? lastLine.length + 1
+      : prevLocation.column + lastLine.length
   };
 };


### PR DESCRIPTION
Fix token location tracker to correctly calculate position of first token on a new line.

Also update the `system/lexer.ts` tests to include token locations