### PR TITLE
Add support for `text`, `atom`, and `comment`

### DIFF
--- a/examples/test.op
+++ b/examples/test.op
@@ -1,4 +1,5 @@
 num = 12
+atom = :thing
 label = n => ("number", n)
 
 (* a comment *)

--- a/src/core/ast.types.ts
+++ b/src/core/ast.types.ts
@@ -8,6 +8,7 @@ export type Node = (
   Func |
   Tuple |
   Name |
+  Atom |
   Numeral |
   Text
 );
@@ -30,6 +31,7 @@ export type Expression = (
   Func |
   Tuple |
   Name |
+  Atom |
   Numeral |
   Text
 );
@@ -55,6 +57,12 @@ export type Name = {
   type: 'name';
   value: string;
   token: TokenMap['name'];
+};
+
+export type Atom = {
+  type: 'atom';
+  value: string;
+  token: TokenMap['atom'];
 };
 
 export type Numeral = {

--- a/src/core/lexer.ts
+++ b/src/core/lexer.ts
@@ -16,6 +16,7 @@ export const lexer = createLexer({
   '.': '.',
 
   name: [/[a-zA-Z][a-zA-Z0-9]*/, s => s],
+  atom: [/:[a-zA-Z]+/, s => s.slice(1)],
   number: [/[0-9]+/, s => parseInt(s, 10)],
   text: [/"[^"]*"/, s => s.slice(1, -1)],
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -45,6 +45,7 @@ const expressionRecSafe: RDParser<AST.Expression> = (handle) => {
     func,
     tuple,
     name,
+    atom,
     number,
     text,
   ]);
@@ -108,6 +109,16 @@ const name: RDParser<AST.Name> = (handle) => {
 
   return {
     type: 'name',
+    value: token.value,
+    token
+  };
+};
+
+const atom: RDParser<AST.Atom> = (handle) => {
+  const token = handle.consume('atom');
+
+  return {
+    type: 'atom',
     value: token.value,
     token
   };

--- a/src/core/stringification.ts
+++ b/src/core/stringification.ts
@@ -62,6 +62,7 @@ const walkers: Walkers<AST.Node, string> = {
     node.members,
   ),
   'name': (node) => stringifyLeaf(node),
+  'atom': (node) => stringifyLeaf(node, v => `:${v}`),
   'number': (node) => stringifyLeaf(node),
   'text': (node) => stringifyLeaf(node, v => `"${v}"`),
 };


### PR DESCRIPTION
Add support for `text`, `atom`, and `comment`. 