### PR TITLE
Fix `comment` Regex

### DIFF
--- a/src/core/lexer.ts
+++ b/src/core/lexer.ts
@@ -3,7 +3,7 @@ import { createTokenFilter, FilterModuleToken } from '&/utils/system/token-filte
 import type { MapByType } from '&/utils/helper.types';
 
 export const lexer = createLexer({
-  comment: /\(\*([^(]|\*(?!\)))*\*\)/,
+  comment: /\(\*([^*]|\*(?!\)))*\*\)/,
 
   '(': '(',
   ')': ')',


### PR DESCRIPTION
## Summary

The lexer would not recognize comments that contained an `(` due to a typo in the regex. 