### PR TITLE
Tweak Function Application

### DIFF
--- a/examples/functions.op
+++ b/examples/functions.op
@@ -1,16 +1,21 @@
+(*
+  semicolon required at the end of each declaration & top level expression (except the last),
+  otherwise it's parsed as fn application and would swallow the beginning of the next line
+*)
+
 (* declaration/lambda *)
-label = n => ("number", n)
+label = n => ("number", n);
 
 (* multiple args *)
-group = a => b => (a, b)
+group = a => b => (a, b);
 
 (* application *)
-label(10)
+label 10;
 
 (* sequential application *)
-bar(baz(x))
+bar (baz x);
 
 (* multiple args *)
-foo(a)(b)(c)
+foo a b c;
 
-group(label(1))(label(2))
+group (label 1) (label 2);

--- a/examples/test.op
+++ b/examples/test.op
@@ -1,12 +1,20 @@
-num = 12
-label = n => ("number", n)
+(*
+  semicolon required at the end of each declaration & top level expression (except the last),
+  otherwise it's parsed as fn application and would swallow the beginning of the next line
+*)
+
+num = 12;
+label = n => ("number", n);
 
 (* a comment *)
-labeledNum = label(num)
-print((* inline comment *)labeledNum)
+labeledNum = label num;
+print (* inline comment *) labeledNum;
 
-atom = :thing
-print(atom)
+atom = :thing;
+print atom;
 
-foo(a)(b)(c)
-bar(baz(x))
+foo a b c;
+bar (baz x);
+
+(* testing precedence *)
+precedence = a => b (c => d) (e, f);

--- a/src/core/ast.types.ts
+++ b/src/core/ast.types.ts
@@ -4,7 +4,7 @@ export type AST = Program;
 export type Node = (
   Program |
   Declaration |
-  FuncCall |
+  FuncApplication |
   Func |
   Tuple |
   Name |
@@ -26,7 +26,7 @@ export type Declaration = {
 };
 
 export type Expression = (
-  FuncCall |
+  FuncApplication |
   Func |
   Tuple |
   Name |
@@ -35,8 +35,8 @@ export type Expression = (
   Text
 );
 
-export type FuncCall = {
-  type: 'function-call';
+export type FuncApplication = {
+  type: 'function-application';
   func: Expression;
   arg: Expression;
 }

--- a/src/core/code-generation.ts
+++ b/src/core/code-generation.ts
@@ -13,7 +13,7 @@ const walkers: Walkers<AST.Node, string> = {
   'declaration': (node, process) =>
     `const ${process(node.name)} = ${process(node.expression)}`,
 
-  'function-call': (node, process) =>
+  'function-application': (node, process) =>
     `${process(node.func)}(${process(node.arg)})`,
   'function': (node, process) =>
     `(${process(node.arg)}) => ${process(node.body)}`,

--- a/src/core/lexer.ts
+++ b/src/core/lexer.ts
@@ -11,6 +11,7 @@ export const lexer = createLexer({
   '=': '=',
 
   ',': ',',
+  ';': ';',
 
   '=>': '=>',
   '.': '.',

--- a/src/core/stringification.ts
+++ b/src/core/stringification.ts
@@ -47,7 +47,7 @@ const walkers: Walkers<AST.Node, string> = {
       node.expression
     ]
   ),
-  'function-call': (node, process) => stringifyBranch(
+  'function-application': (node, process) => stringifyBranch(
     process,
     node.type,
     [


### PR DESCRIPTION
## Summary

Switch function application from parenthesis based (`f(x)`) to proximity based (`f x`); this mimics the way most of the well known "functional languages" (eg Haskell, MLs) do it.

To make this work cleanly, I had to allow optional semicolons to mark the end of a declaration or expression (so that the function application doesn't just swallow the beginning of every adjacent expression). I may address this issue differently later, possibly using significant newlines.