### PR TITLE
Block Expressions

### DIFF
--- a/src/core/ast.types.ts
+++ b/src/core/ast.types.ts
@@ -4,6 +4,7 @@ export type AST = Program;
 export type Node = (
   Program |
   Declaration |
+  BlockExpression |
 
   FuncApplication |
   ThunkForce |
@@ -38,7 +39,13 @@ export type Declaration = {
   expression: Expression;
 };
 
+export type BlockExpression = {
+  type: 'block-expression';
+  entries: (Declaration | Expression)[];
+};
+
 export type Expression = (
+  BlockExpression |
   FuncApplication |
   ThunkForce |
   Match |

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,4 +1,4 @@
-import { createRDParser, repeated, optional, choice } from '&/utils/system/parser';
+import { createRDParser, repeated, optional, choice, repeatedRequired } from '&/utils/system/parser';
 import { FilteredToken } from './lexer';
 import type * as AST from './ast.types';
 import { lrec } from '&/utils/system/parser/lrec';
@@ -47,7 +47,7 @@ const declaration: RDParser<AST.Declaration> = cached((handle, ctx) => {
 });
 
 const blockExpression: RDParser<AST.BlockExpression | AST.Expression> = cached((handle, ctx) => {
-  const [entries, error] = repeated(handle, ctx, () => {
+  const [entries] = repeatedRequired(1, handle, ctx, () => {
     const entry = choice(handle, ctx, [
       declaration,
       expression
@@ -59,10 +59,6 @@ const blockExpression: RDParser<AST.BlockExpression | AST.Expression> = cached((
 
     return entry;
   });
-
-  if (entries.length < 1) {
-    throw error;
-  }
 
   if (entries.length === 1 && entries[0].type !== 'declaration') {
     return entries[0];
@@ -128,7 +124,7 @@ const match: RDParser<AST.Match, PrecedenceContext> = (handle, ctx) => {
 const matchClauses: RDParser<AST.MatchClause[]> = (handle, ctx) => {
   handle.consume('(');
 
-  const [clauses, lastError] = repeated(handle, ctx, () => {
+  const [clauses] = repeatedRequired(1, handle, ctx, () => {
     const clause = matchClause(handle, ctx);
 
     optional(handle, ctx, () => {
@@ -137,10 +133,6 @@ const matchClauses: RDParser<AST.MatchClause[]> = (handle, ctx) => {
 
     return clause;
   });
-
-  if (clauses.length < 1) {
-    throw lastError;
-  }
 
   handle.consume(')');
 

--- a/src/core/stringification.ts
+++ b/src/core/stringification.ts
@@ -57,6 +57,11 @@ const walkers: Walkers<AST.Node, string> = {
       node.expression
     ]
   ),
+  'block-expression': (node, process) => stringifyBranch(
+    process,
+    node.type,
+    node.entries
+  ),
   'function-application': (node, process) => stringifyBranch(
     process,
     node.type,

--- a/src/utils/system/parser/combinators.ts
+++ b/src/utils/system/parser/combinators.ts
@@ -1,3 +1,4 @@
+import { TupleOf } from '&/utils/tuple.types';
 import { RDParser } from './common.types';
 import { CompositeParseError, ParseError } from './errors';
 import { ConsumeHandle } from './handles';
@@ -57,6 +58,27 @@ export const repeated = <H extends ConsumeHandle, C, R>(handle: H, context: C, p
   }
 
   return [[], error];
+};
+
+
+type TupleOfMin<T, N extends number> =
+  N extends 0 ? T[] :
+  [...TupleOf<T, N>, ...T[]];
+
+export const repeatedRequired = <N extends number, H extends ConsumeHandle, C, R>(
+  n: N,
+  handle: H,
+  context: C,
+  parser: RDParser<H, C, R>
+): [TupleOfMin<R, N>, Error] => {
+  if (n < 1) {
+    return repeated(handle, context, parser) as [TupleOfMin<R, N>, Error];
+  }
+
+  const entry = parser(handle, context);
+  const [rest, error] = repeatedRequired(n - 1, handle, context, parser);
+
+  return [[entry, ...rest] as TupleOfMin<R, N>, error];
 };
 
 

--- a/src/utils/tuple.types.ts
+++ b/src/utils/tuple.types.ts
@@ -16,3 +16,17 @@ export type Last<L extends unknown[]> =
 
 
 export type Prepend<L extends unknown[], T> = [T, ...L];
+
+
+export type TupleOf<T, N extends number> =
+  N extends unknown         // distribute across unions
+    ? number extends N
+      ? T[]
+      : _TupleOf<T, N, []>
+    : never;
+
+// builds tuple until it's length matches N
+type _TupleOf<T, N extends number, R extends unknown[]> =
+  R['length'] extends N
+    ? R
+    : _TupleOf<T, N, [T, ...R]>;


### PR DESCRIPTION
## Summary

Add support for block expressions.

Block expressions are a group of declarations & expressions. They evaluate to the last item (if the last item is a declaration, then it returns `undefined`). Block expressions only occur inside of `()` or `{}`.

If a block expression only contains a single expression, the parser emits the expression directly rather than wrapping it in a `BlockExpression`.

I also added a new parser combinator `repeatedRequired()` that works the same as `repeated()` but throws if the required number of parsed entries are not fulfilled.