### PR TITLE
Smoke Test

### DIFF
--- a/src/__tests__/__snapshots__/smoke.spec.ts.snap
+++ b/src/__tests__/__snapshots__/smoke.spec.ts.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`smoke test (snapshot) matches snapshot 1`] = `
+"
+/* runtime goes here */
+  
+
+const boolean = true;
+
+const number = 12;
+
+const atom = Symbol.for('hello');
+
+const text = \\"hello world\\";
+
+const tuple = {
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: atom,
+  _1: text
+};
+
+const pair = (a) => (b) => ({
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: a,
+  _1: b
+});
+
+pair(pair(1)(2))(pair(3)(4));
+
+((a) => (b) => ({
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: b,
+  _1: a
+}))(1)(2);
+
+const message = (name) => ((subject) => {
+  if (__opus_internals__.match.simpleLiteral(subject, Symbol.for('hello'))) {
+    return \\"hello world\\";
+  } else if (__opus_internals__.match.simpleLiteral(subject, Symbol.for('bye'))) {
+    return \\"bye everyone\\";
+  } else {
+    return \\"other\\";
+  }
+})(name);
+
+const a = Symbol.for('a');
+
+const b = Symbol.for('b');
+
+const c = Symbol.for('c');
+
+const d = Symbol.for('d');
+
+const f = (x) => x;
+
+const g = (x) => x;
+
+(x) => ((subject) => {
+  {
+    return x;
+  }
+})(x);
+
+(x) => f(x);
+
+f(g)(a);
+
+f(g(a));
+
+{
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: (x) => a,
+  _1: (y) => b
+};
+
+{
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: ((subject) => {
+    {
+      return a;
+    }
+  })(a),
+  _1: f(a)
+};
+
+((subject) => {
+  {
+    return a;
+  }
+})(f(b));
+
+(x) => ((subject) => {
+  {
+    return (y) => b;
+  }
+})(a)((z) => c)({
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: d,
+  _1: f(x)
+});
+"
+`;

--- a/src/__tests__/smoke.spec.ts
+++ b/src/__tests__/smoke.spec.ts
@@ -1,0 +1,69 @@
+import { core } from '../core';
+import { Input } from '../utils/system/input';
+import fs from 'fs';
+
+jest.mock('&/core/runtime', () => {
+  const mockRuntime = `
+/* runtime goes here */
+  `;
+
+  return {
+    __esModule: true,
+    injectRuntime: {
+      run: (output: string) => {
+        return mockRuntime + '\n\n' + output;
+      }
+    }
+  };
+});
+
+
+const source = Input.fromString('raw', `
+(* comment *)
+boolean = true;
+number = 12;
+atom = :hello;
+text = "hello world";
+
+tuple = (atom, text);
+
+(* functions *)
+pair = a => b => (a, b);
+pair (pair 1 2) (pair 3 4);
+
+(* inline function *)
+(a => b => (b, a)) 1 2;
+
+(* pattern match *)
+message = name => name match (
+  :hello => "hello world";
+  :bye => "bye everyone";
+  _ => "other";
+);
+
+(* ------------------- *)
+(* precedence *)
+
+a = :a; b = :b; c = :c; d = :d;
+f = x => x; g = x => x;
+
+x => x match (_ => x);
+x => f x;
+
+f g a;
+f (g a);
+
+(x => a, y => b);
+(a match (_ => a), f a);
+
+f b match (_ => a);
+
+x => a match (_ => y => b) (z => c) (d, f x);
+`);
+
+describe('smoke test (snapshot)', () => {
+  it('matches snapshot', () => {
+    fs.readFileSync(require.resolve('&&/runtime/main'), 'utf-8');
+    expect(core().run(source)).toMatchSnapshot();
+  });
+});

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -14,7 +14,8 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
     '^&/(.*)$': '<rootDir>/src/$1',
-    '^&test/(.*)$': '<rootDir>/test/$1'
+    '^&test/(.*)$': '<rootDir>/test/$1',
+    '^&&/(.*)$': '<rootDir>/$1',
   },
   setupFilesAfterEnv: [
     'jest-extended'


### PR DESCRIPTION
## Summary

Add a basic smoke test to make refactoring safer. The smoke test runs the compiler on a quick sample of all the currently supported syntax & compares the generated code to a snapshot. The runtime is mocked out to keep the snapshot slimmer.