### PR TITLE
Allow Reading Input From Stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,19 @@ start             - runs the compiler (prints generated code to stdout)
 start:pure        - runs the compiler without rebuilding
 
 start:run         - runs the compiler & immediately runs the result (via nodejs)
-start:in          - runs the compiler using stdin (not a repl - reads the entire input before running)
 start:example     - runs the compiler on one of the example files
 (NOTE - the examples may contain syntax that is not yet implemented)
 ```
 
-And here are some of the supported cli flags:
+Usage of the actual compiler:
 ```
+npm run start -- [options] [file | -]
+
+passing - instead of a file reads from the stdin with one caveat:
+the input must be piped in (eg using direct pipe, heredoc, file redirect, etc);
+running on interactive/user input is not supported and will error.
+
+Options:
 -h / --help       prints the usage information
 -v / --version    prints the version
 -o / --output t   changes what stage of the compiler is output
@@ -100,6 +106,11 @@ Example commands:
 ```sh
 # compiles "./my-file.op"
 npm run start -- ./my-file.op
+
+# compiles using a heredoc as input
+npm run start -- - <<EOI
+  (* your code here *)
+EOI
 
 # compiles & immediately runs "./my-file.op"
 npm run start:run -- ./my-file.op

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start:pure": "node ./build/index.js",
     "start": "npm run build && npm run start:pure --",
     "start:run": "npm run and-run -- start",
-    "start:in": "cat > .tmp.op && npm run start -- .tmp.op && rm .tmp.op",
     "start:example": "run() { npm start -- ./examples/${1:-test}.op \"${@:2}\"; }; run",
     "start:run:example": "npm run and-run -- start:example",
     "and-run": "run() { npm run $1 --silent -- \"${@:2}\" | node; }; run",

--- a/src/utils/system/input.ts
+++ b/src/utils/system/input.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 
 export type Source = string;
 export type Input = {
@@ -7,5 +8,15 @@ export type Input = {
 
 export const Input = {
   fromString: (source: Source, content: string): Input =>
-    ({ source, content })
+    ({ source, content }),
+
+  fromFile: (file: string): Input => {
+    const content = fs.readFileSync(file, 'utf-8');
+    return { source: `file:${file}`, content };
+  },
+
+  fromStdin: (): Input => {
+    const content = fs.readFileSync(process.stdin.fd, 'utf-8');
+    return { source: 'stdin', content };
+  }
 };


### PR DESCRIPTION
## Summary

Allow reading input from stdin, not just from a file. 

**NOTE:** this is just meant to ease development & testing, and as such is a quick & dirty implementation and has several caveats: Input must be piped in (eg using direct pipe, heredoc, file redirect, etc) - it doesn't support running the compiler & then typing input in interactively. Additionally, it's may not work on all systems/os's.