### PR TITLE
Fix Parser Bug

### DIFF
--- a/examples/hello-world.op
+++ b/examples/hello-world.op
@@ -21,4 +21,4 @@ main = {
 *)
 
 !main with
-  IO.file.write './hello-world.txt';
+  IO.file.write "./hello-world.txt";

--- a/examples/syntax.op
+++ b/examples/syntax.op
@@ -78,7 +78,7 @@ log = x => (
 log "foo";  (* uses default/builtin handler - prints to stdout *)
 
 log "foo" with
-  IO.file.write './foo.txt';
+  IO.file.write "./foo.txt";
 (* uses builtin file IO handler - prints to file *)
 
 (* can create a handler inline *)

--- a/src/__tests__/__snapshots__/smoke.spec.ts.snap
+++ b/src/__tests__/__snapshots__/smoke.spec.ts.snap
@@ -155,6 +155,10 @@ f(g(a));
 })(f(b));
 
 (x) => ((subject) => {
+  return f;
+})(x)(b);
+
+(x) => ((subject) => {
   return (y) => b;
 })(a)((z) => c)({
   __opus_kind__: 'tuple',

--- a/src/__tests__/__snapshots__/smoke.spec.ts.snap
+++ b/src/__tests__/__snapshots__/smoke.spec.ts.snap
@@ -107,10 +107,39 @@ const delay = (x) => () => x;
 
 {
   __opus_kind__: 'tuple',
-  size: 2,
+  size: 3,
   _0: delay(1)(),
   _1: (() => 2)(),
+  _2: delay((() => 3)())(),
 };
+
+const tdelay = () => delay;
+
+tdelay()(1);
+
+tdelay()(1)();
+
+const doubleDelay = (x) => (y) => () => () => ({
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: x,
+  _1: y,
+});
+
+doubleDelay(1)(2)()();
+
+const pair = (x) => (y) => ({
+  __opus_kind__: 'tuple',
+  size: 2,
+  _0: x,
+  _1: y,
+});
+
+pair(one())(two());
+
+const apply = (f) => (x) => f(x);
+
+apply(tdelay())(1)();
 
 const a = Symbol.for('a');
 

--- a/src/__tests__/smoke.spec.ts
+++ b/src/__tests__/smoke.spec.ts
@@ -1,6 +1,5 @@
 import { core } from '../core';
 import { Input } from '../utils/system/input';
-import fs from 'fs';
 
 jest.mock('&/core/runtime', () => {
   const mockRuntime = '\n/* runtime goes here */\n';
@@ -99,13 +98,13 @@ f (g a);
 (a match (_ => a), f a);
 
 f b match (_ => a);
+x => x match (_ => f) (b);
 
 x => a match (_ => y => b) (z => c) (d, f x);
 `);
 
 describe('smoke test (snapshot)', () => {
   it('matches snapshot', () => {
-    fs.readFileSync(require.resolve('&&/runtime/main'), 'utf-8');
     expect(core().run(source)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/smoke.spec.ts
+++ b/src/__tests__/smoke.spec.ts
@@ -75,12 +75,23 @@ oneAndTwo = {
 
 delay = x => { x };
 
-(!(delay 1), !{ 2 });
+(!(delay 1), !{ 2 }, !(delay !{ 3 }));
 
-(*
-  (!(delay 1), !{ 2 }, !(delay !{ 3 }));
-*)
+(* nested thunks *)
+tdelay = { delay };
+!tdelay 1;
+!(!tdelay 1);
 
+(* double thunk *)
+doubleDelay = x => y => { { (x, y) } };
+!!(doubleDelay 1 2);
+
+(* inline forcing as fn args *)
+pair = x => y => (x, y);
+pair !one !two;
+
+apply = f => x => f x;
+!(apply !tdelay 1);
 
 (* ------------------- *)
 (* precedence *)

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -77,21 +77,15 @@ const precedenceCacheKey = (ctx: object, precedence: number) => `prec=${preceden
 const topPrecedenceCacheKey = (ctx: object, precedence = 0) =>
   precedenceCacheKey(ctx, precedence);
 
-// TODO - cached is definitely necessary here... -> build it into lrec..?
-// -> can't use cached cache in lrec as is -> lrec busts cached cache
-// -> may be able to switch to a cache key & have it work?
-const expression: TopPrecedenceParser<AST.Expression> = cached(
+const expression: TopPrecedenceParser<AST.Expression> = lrec.cached(
   topPrecedenceCacheKey,
-  lrec(
-    topPrecedenceCacheKey,
-    (handle, ctx, precedence = 0) => {
-      return precedented(handle, ctx, { precedence, rec: expression }, [
-        [match, funcApplication],
-        [thunkForce],
-        [parens, literal, name]
-      ]);
-    }
-  )
+  (handle, ctx, precedence = 0) => {
+    return precedented(handle, ctx, { precedence, rec: expression }, [
+      [match, funcApplication],
+      [thunkForce],
+      [parens, literal, name]
+    ]);
+  }
 );
 
 const parens: RDParser<AST.Expression> = cached((handle, ctx) => {

--- a/src/utils/system/parser/__tests__/cache.spec.js
+++ b/src/utils/system/parser/__tests__/cache.spec.js
@@ -3,7 +3,35 @@ import { cached } from '../cache';
 import { createRDParser } from '..';
 import { choice } from '../combinators';
 
+const createCached = (rule, keySuffix) => {
+  const trackedRule = jest.fn(rule);
+
+  let cachedParser;
+  if (keySuffix) {
+    cachedParser = cached(keySuffix, trackedRule);
+  } else {
+    cachedParser = cached(trackedRule);
+  }
+
+  cachedParser.rule = trackedRule;
+
+  return cachedParser;
+};
+
+const argsKeySuffix = (_ctx, ...args) => args.join(':');
+
+const cachedA = createCached(a);
+const cachedB = createCached(b);
+const cachedC = createCached(c);
+const cachedD = createCached(d);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 it('caches successful parse results', () => {
+  const trackedB = jest.fn(b);
+
   const start = (handle, ctx) => {
     const node = choice(handle, ctx, [ABC, ABD]);
     handle.consumeEOI();
@@ -16,7 +44,7 @@ it('caches successful parse results', () => {
 
   const ABC = (handle, ctx) => {
     const nodeA = cachedA(handle, ctx);
-    const nodeB = rawB(handle, ctx);
+    const nodeB = trackedB(handle, ctx);
     const nodeC = c(handle, ctx);
 
     return {
@@ -27,7 +55,7 @@ it('caches successful parse results', () => {
 
   const ABD = (handle, ctx) => {
     const nodeA = cachedA(handle, ctx);
-    const nodeB = rawB(handle, ctx);
+    const nodeB = trackedB(handle, ctx);
     const nodeD = d(handle, ctx);
 
     return {
@@ -35,10 +63,6 @@ it('caches successful parse results', () => {
       children: [nodeA, nodeB, nodeD]
     };
   };
-
-  const rawA = jest.fn(a);
-  const rawB = jest.fn(b);
-  const cachedA = cached(rawA);
 
   const parser = createRDParser(start);
 
@@ -57,8 +81,8 @@ it('caches successful parse results', () => {
     }
   });
 
-  expect(rawA).toHaveBeenCalledTimes(1);
-  expect(rawB).toHaveBeenCalledTimes(2);
+  expect(cachedA.rule).toHaveBeenCalledTimes(1);
+  expect(trackedB).toHaveBeenCalledTimes(2);
 });
 
 it('caches failed parses', () => {
@@ -92,9 +116,6 @@ it('caches failed parses', () => {
     };
   };
 
-  const rawA = jest.fn(a);
-  const cachedA = cached(rawA);
-
   const parser = createRDParser(start);
 
   const input = tokenIterator(['d']);
@@ -105,7 +126,7 @@ it('caches failed parses', () => {
     node: { type: 'd', token: input.tokens[0] }
   });
 
-  expect(rawA).toHaveBeenCalledTimes(1);
+  expect(cachedA.rule).toHaveBeenCalledTimes(1);
 });
 
 it('caches based on position/mark', () => {
@@ -120,9 +141,6 @@ it('caches based on position/mark', () => {
     };
   };
 
-  const rawA = jest.fn(a);
-  const cachedA = cached(rawA);
-
   const parser = createRDParser(start);
 
   const input = tokenIterator(['a', 'a']);
@@ -136,24 +154,127 @@ it('caches based on position/mark', () => {
     ]
   });
 
-  expect(rawA).toHaveBeenCalledTimes(2);
+  expect(cachedA.rule).toHaveBeenCalledTimes(2);
+});
+
+it('caches based on context if specified', () => {
+  const cachedCtxA = createCached(
+    (h, c) => ({ ...a(h, c), key: c.key }),
+    (c) => c.key
+  );
+
+  const nodes = (handle, context) => choice(handle, context, [
+    (h, ctx) => {
+      const n1 = cachedCtxA(h, { ...ctx, key: ctx.key1 });
+      const n2 = b(h, ctx);
+      return [n1, n2];
+    },
+    (h, ctx) => {
+      const n1 = cachedCtxA(h, { ...ctx, key: ctx.key2 });
+      const n2 = c(h, ctx);
+      return [n1, n2];
+    },
+    (h, ctx) => {
+      const n1 = cachedCtxA(h, { ...ctx, key: ctx.key3 });
+      const n2 = d(h, ctx);
+      return [n1, n2];
+    },
+  ]);
+
+  const start = (handle, ctx) => {
+    const children = nodes(handle, ctx);
+
+    handle.consumeEOI();
+
+    return {
+      type: 'start',
+      children
+    };
+  };
+
+  const parser1 = createRDParser(start, { key1: '1', key2: '2', key3: '1' });
+
+  const input1 = tokenIterator(['a', 'd']);
+  const result1 = parser1.run(input1);
+
+  expect(result1).toEqual({
+    type: 'start',
+    children: [
+      { type: 'a', token: input1.tokens[0], key: '1' },
+      { type: 'd', token: input1.tokens[1] },
+    ]
+  });
+
+  expect(cachedCtxA.rule).toHaveBeenCalledTimes(2);
+});
+
+it('caches parsers with extra parameters', () => {
+  const cachedArgsA = createCached(
+    (h, c, ...args) => ({ ...a(h, c), args }),
+    argsKeySuffix
+  );
+
+  const nodes = (handle, context) => choice(handle, context, [
+    (h, ctx) => {
+      const n1 = cachedArgsA(h, ctx, ...(ctx.args1 ?? []));
+      const n2 = b(h, ctx);
+      return [n1, n2];
+    },
+    (h, ctx) => {
+      const n1 = cachedArgsA(h, ctx, ...(ctx.args2 ?? []));
+      const n2 = c(h, ctx);
+      return [n1, n2];
+    },
+    (h, ctx) => {
+      const n1 = cachedArgsA(h, ctx, ...(ctx.args3 ?? []));
+      const n2 = d(h, ctx);
+      return [n1, n2];
+    },
+  ]);
+
+  const start = (handle, ctx) => {
+    const children = nodes(handle, ctx);
+
+    handle.consumeEOI();
+
+    return {
+      type: 'start',
+      children
+    };
+  };
+
+  const parser1 = createRDParser(start, { args1: [1], args2: [2], args3: [1] });
+
+  const input1 = tokenIterator(['a', 'd']);
+  const result1 = parser1.run(input1);
+
+  expect(result1).toEqual({
+    type: 'start',
+    children: [
+      { type: 'a', token: input1.tokens[0], args: [1] },
+      { type: 'd', token: input1.tokens[1] },
+    ]
+  });
+  expect(cachedArgsA.rule).toHaveBeenCalledTimes(2);
+
+  jest.clearAllMocks();
+
+  const parser2 = createRDParser(start, { args1: [1], args2: [1, 2], args3: [1, 2, 3] });
+
+  const input2 = tokenIterator(['a', 'd']);
+  const result2 = parser2.run(input2);
+
+  expect(result2).toEqual({
+    type: 'start',
+    children: [
+      { type: 'a', token: input2.tokens[0], args: [1, 2, 3] },
+      { type: 'd', token: input2.tokens[1] },
+    ]
+  });
+  expect(cachedArgsA.rule).toHaveBeenCalledTimes(3);
 });
 
 describe('reevaluate', () => {
-  let count = {};
-  const createCached = (name, rule) => cached((handle, context) => {
-    count[name] = (count[name] ?? 0) + 1;
-
-    const node = rule(handle, context);
-
-    return { ...node, count: count[name] };
-  });
-
-  const cachedA = createCached('a', a);
-  const cachedB = createCached('b', b);
-  const cachedC = createCached('c', c);
-  const cachedD = createCached('d', d);
-
   const nodes = (handle, context) => choice(handle, context, [
     (h, c) => {
       const n1 = cachedA(h, c);
@@ -168,10 +289,6 @@ describe('reevaluate', () => {
       return [n1, n2, n3];
     },
   ]);
-
-  beforeEach(() => {
-    count = {};
-  });
 
   it('forces cache to reevaluate entire subtree', () => {
     const start = (handle, ctx) => {
@@ -195,11 +312,14 @@ describe('reevaluate', () => {
     expect(result).toEqual({
       type: 'start',
       children: [
-        { type: 'a', token: input.tokens[0], count: 2 },
-        { type: 'b', token: input.tokens[1], count: 2 },
-        { type: 'd', token: input.tokens[2], count: 1 },
+        { type: 'a', token: input.tokens[0] },
+        { type: 'b', token: input.tokens[1] },
+        { type: 'd', token: input.tokens[2] },
       ]
     });
+
+    expect(cachedA.rule).toHaveBeenCalledTimes(2);
+    expect(cachedB.rule).toHaveBeenCalledTimes(2);
   });
 
   it('forces cache to reevaluate rule base on mark', () => {
@@ -225,10 +345,13 @@ describe('reevaluate', () => {
     expect(result).toEqual({
       type: 'start',
       children: [
-        { type: 'a', token: input.tokens[0], count: 2 },
-        { type: 'b', token: input.tokens[1], count: 1 },
-        { type: 'd', token: input.tokens[2], count: 1 },
+        { type: 'a', token: input.tokens[0] },
+        { type: 'b', token: input.tokens[1] },
+        { type: 'd', token: input.tokens[2] },
       ]
     });
+
+    expect(cachedA.rule).toHaveBeenCalledTimes(2);
+    expect(cachedB.rule).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/system/parser/__tests__/lrec.spec.js
+++ b/src/utils/system/parser/__tests__/lrec.spec.js
@@ -481,7 +481,7 @@ describe('nested', () => {
       };
     };
 
-    const r1 = cached(lrec((handle, ctx) => {
+    const r1 = lrec.cached((handle, ctx) => {
       const node = choice(handle, ctx, [
         () => {
           const n = r2(handle, ctx);
@@ -499,16 +499,16 @@ describe('nested', () => {
         type: 'r1',
         node
       };
-    }));
+    });
 
-    const r2 = cached(lrec((handle, ctx) => {
+    const r2 = lrec.cached((handle, ctx) => {
       const node = choice(handle, ctx, [rb, ra, c]);
 
       return {
         type: 'r2',
         node
       };
-    }));
+    });
 
     const ra = (handle, ctx) => {
       const rec = r1(handle, ctx);

--- a/src/utils/system/parser/__tests__/precedence.spec.js
+++ b/src/utils/system/parser/__tests__/precedence.spec.js
@@ -38,8 +38,8 @@ const lassoc = p => [p, p+1];
 const rassoc = p => [p+1, p];
 
 const rules = {
-  binary:  (op, ps) => rec => (handle, ctx) => {
-    const [lp, rp] = ps(ctx.precedence);
+  binary:  (op, ps) => rec => (handle, ctx, precedence) => {
+    const [lp, rp] = ps(precedence);
 
     const left = rec(handle, ctx, lp);
     handle.consume(op);
@@ -48,8 +48,8 @@ const rules = {
     return { type: 'op', op, left, right };
   },
 
-  apply: (ps = lassoc) => rec => (handle, ctx) => {
-    const [lp, rp] = ps(ctx.precedence);
+  apply: (ps = lassoc) => rec => (handle, ctx, precedence) => {
+    const [lp, rp] = ps(precedence);
 
     const left = rec(handle, ctx, lp);
     const right = rec(handle, ctx, rp);

--- a/src/utils/system/parser/lrec.ts
+++ b/src/utils/system/parser/lrec.ts
@@ -1,6 +1,6 @@
 import { Comparison } from '&/utils/comparison';
 import { CacheContext } from './cache';
-import { ExtendedRDParser } from './common.types';
+import { ExtendedRDParser, RDParser } from './common.types';
 import { UnrestrainedLeftRecursion } from './errors';
 import { ConsumeHandle } from './handles';
 import { compareMarks } from './mark';
@@ -12,13 +12,38 @@ import { ParseCache } from './parse-cache';
   essentially calculates the fixpoint of the parser given the input (not exactly... only compares the position/mark, not the result)
 */
 
-export const lrec = <H extends ConsumeHandle, C, As extends unknown[], R>(parser: ExtendedRDParser<H, C, As, R>): ExtendedRDParser<H, C, As, R> => {
+type KeySuffix<C, As extends unknown[]> =
+  (ctx: C, ...args: As) => string | undefined;
+
+type LRec = {
+  <H extends ConsumeHandle, C, R>(parser: RDParser<H, C, R>): RDParser<H, C, R>;
+  <H extends ConsumeHandle, C, As extends unknown[], R>(
+    keySuffix: KeySuffix<C, As>,
+    parser: ExtendedRDParser<H, C, As, R>
+  ): ExtendedRDParser<H, C, As, R>;
+};
+
+export const lrec: LRec = <H extends ConsumeHandle, C, As extends unknown[], R>(
+  _keySuffix: KeySuffix<C, As> | ExtendedRDParser<H, C, As, R>,
+  _parser?: ExtendedRDParser<H, C, As, R>
+): ExtendedRDParser<H, C, As, R> => {
+  let keySuffix: KeySuffix<C, As>;
+  let parser: ExtendedRDParser<H, C, As, R>;
+
+  if (_parser === undefined) {
+    keySuffix = () => undefined;
+    parser = _keySuffix as ExtendedRDParser<H, C, As, R>;
+  } else {
+    keySuffix = _keySuffix as KeySuffix<C, As>;
+    parser = _parser;
+  }
+
   const cache = new ParseCache<R>();
 
   return (handle, context: C & CacheContext, ...args) => {
 
     const start = handle.mark();
-    const cacheKey = ParseCache.key(start);
+    const cacheKey = ParseCache.key(start, keySuffix(context, ...args));
 
     const entry = cache.get(cacheKey);
     if (entry) {

--- a/src/utils/system/parser/parse-cache.ts
+++ b/src/utils/system/parser/parse-cache.ts
@@ -8,7 +8,12 @@ export type CacheEntry<R> =
 type CacheKey = string & { __brand: 'parse-cache-key' };
 
 export class ParseCache<T> extends Map<CacheKey, CacheEntry<T>> {
-  static key(mark: Mark): CacheKey {
-    return serializeMark(mark) as CacheKey;
+  static key(mark: Mark, suffix?: string): CacheKey {
+    const sMark = serializeMark(mark);
+    if (suffix != null) {
+      return `${sMark}::${suffix}` as CacheKey;
+    } else {
+      return sMark as CacheKey;
+    }
   }
 }

--- a/src/utils/system/parser/precedence.ts
+++ b/src/utils/system/parser/precedence.ts
@@ -1,40 +1,73 @@
 import { choice } from '.';
-import { RDParser } from './common.types';
+import { ExtendedRDParser, RDParser } from './common.types';
 import { ConsumeHandle } from './handles';
 
 export type PrecedenceContext = {
   precedence: number;
 };
 
+type ParserTable<H extends ConsumeHandle, C, R> =
+  RDParser<H, C & PrecedenceContext, R>[][];
+
+type PrecedenceTable<H extends ConsumeHandle, C, R> =
+  RDParser<H, C, R>[];
+
+type PrecedenceRec<H extends ConsumeHandle, C, R> =
+  ExtendedRDParser<H, C, [precedence: number], R>;
+
+const nextLevel = <H extends ConsumeHandle, C, R>(
+  rec: PrecedenceRec<H, C, R>,
+  level: number
+): RDParser<H, C, R> =>
+    (h, c) => rec(h, c, level + 1);
+
+const buildPrecedenceTable = <H extends ConsumeHandle, C, R>(
+  parserTable: ParserTable<H, C, R>,
+  rec?: PrecedenceRec<H, C, R>
+): PrecedenceTable<H, C, R> => {
+
+  const parserTableWithContext = parserTable.map((parsers, level) =>
+    parsers.map<RDParser<H, C, R>>(parser =>
+      (h, c) => parser(h, { ...c, precedence: level })
+    )
+  );
+
+  const choices = parserTableWithContext.reduceRight<RDParser<H, C, R>[]>((precedenceLevels, parsers, level) => {
+    const nextPrecedenceLevel: RDParser<H, C, R> | undefined = rec
+      ? nextLevel(rec, level)
+      : precedenceLevels[0];
+
+    const currentChoices = nextPrecedenceLevel
+      ? [...parsers, nextPrecedenceLevel]
+      : parsers;
+
+    const currentPrecedenceLevel: RDParser<H, C, R> = (handle, context) =>
+      choice(handle, context, currentChoices);
+
+    return [currentPrecedenceLevel, ...precedenceLevels];
+  }, [] as RDParser<H, C, R>[]);
+
+  return choices;
+};
+
+type PrecedentedOptions<H extends ConsumeHandle, C, R> = {
+  precedence: number;
+  rec?: PrecedenceRec<H, C, R>;
+};
+
 export const precedented = <H extends ConsumeHandle, C, R, Ps extends RDParser<H, C & PrecedenceContext, R>[][]>(
   handle: H,
   context: C,
-  precedence: number,
+  { precedence, rec }: PrecedentedOptions<H, C, R>,
   parserTable: Ps
 ): R => {
   if (precedence < 0 && precedence >= parserTable.length) {
     throw new Error(`precedence out of bounds of parserTable (0 .. ${parserTable.length - 1})`);
   }
 
-  const choices: RDParser<H, C, R>[] = parserTable.reduceRight<RDParser<H, C, R>[]>((precedenceLevels, parsers, level) => {
-    const refinedParsers = parsers.map<RDParser<H, C, R>>(parser =>
-      (h, c) => parser(h, { ...c, precedence: level })
-    );
+  const precedenceTable = buildPrecedenceTable(parserTable, rec);
 
-    const nextPrecedenceLevel: RDParser<H, C, R> | undefined = precedenceLevels[0];
-
-    const currentPrecedenceLevel: RDParser<H, C, R> = (handle, context) => {
-      const currentChoices = nextPrecedenceLevel
-        ? [...refinedParsers, nextPrecedenceLevel]
-        : refinedParsers;
-
-      return choice(handle, context, currentChoices);
-    };
-
-    return [currentPrecedenceLevel, ...precedenceLevels];
-  }, [] as RDParser<H, C, R>[]);
-
-  const precedenceParser: RDParser<H, C, R> = choices[precedence];
+  const precedenceParser: RDParser<H, C, R> = precedenceTable[precedence];
 
   return precedenceParser(handle, context);
 };

--- a/src/utils/system/parser/precedence.ts
+++ b/src/utils/system/parser/precedence.ts
@@ -2,47 +2,49 @@ import { choice } from '.';
 import { ExtendedRDParser, RDParser } from './common.types';
 import { ConsumeHandle } from './handles';
 
-export type PrecedenceContext = {
-  precedence: number;
-};
+export type PrecedenceParser<H extends ConsumeHandle, C, R> =
+  ExtendedRDParser<H, C, [precedence: number], R>;
 
 type ParserTable<H extends ConsumeHandle, C, R> =
-  RDParser<H, C & PrecedenceContext, R>[][];
+  PrecedenceParser<H, C, R>[][];
 
 type PrecedenceTable<H extends ConsumeHandle, C, R> =
   RDParser<H, C, R>[];
 
-type PrecedenceRec<H extends ConsumeHandle, C, R> =
-  ExtendedRDParser<H, C, [precedence: number], R>;
 
 const nextLevel = <H extends ConsumeHandle, C, R>(
-  rec: PrecedenceRec<H, C, R>,
+  rec: PrecedenceParser<H, C, R>,
   level: number
 ): RDParser<H, C, R> =>
     (h, c) => rec(h, c, level + 1);
 
 const buildPrecedenceTable = <H extends ConsumeHandle, C, R>(
   parserTable: ParserTable<H, C, R>,
-  rec?: PrecedenceRec<H, C, R>
+  rec?: PrecedenceParser<H, C, R>
 ): PrecedenceTable<H, C, R> => {
 
   const parserTableWithContext = parserTable.map((parsers, level) =>
     parsers.map<RDParser<H, C, R>>(parser =>
-      (h, c) => parser(h, { ...c, precedence: level })
+      (h, c) => parser(h, c, level)
     )
   );
 
   const choices = parserTableWithContext.reduceRight<RDParser<H, C, R>[]>((precedenceLevels, parsers, level) => {
-    const nextPrecedenceLevel: RDParser<H, C, R> | undefined = rec
-      ? nextLevel(rec, level)
-      : precedenceLevels[0];
+    let nextPrecedenceLevel: RDParser<H, C, R> | undefined = undefined;
+
+    if (level < parserTableWithContext.length - 1) {
+      nextPrecedenceLevel = rec
+        ? nextLevel(rec, level)
+        : precedenceLevels[0];
+    }
 
     const currentChoices = nextPrecedenceLevel
       ? [...parsers, nextPrecedenceLevel]
       : parsers;
 
-    const currentPrecedenceLevel: RDParser<H, C, R> = (handle, context) =>
-      choice(handle, context, currentChoices);
+    const currentPrecedenceLevel: RDParser<H, C, R> = (handle, context) => {
+      return choice(handle, context, currentChoices);
+    };
 
     return [currentPrecedenceLevel, ...precedenceLevels];
   }, [] as RDParser<H, C, R>[]);
@@ -50,12 +52,13 @@ const buildPrecedenceTable = <H extends ConsumeHandle, C, R>(
   return choices;
 };
 
+
 type PrecedentedOptions<H extends ConsumeHandle, C, R> = {
   precedence: number;
-  rec?: PrecedenceRec<H, C, R>;
+  rec?: PrecedenceParser<H, C, R>;
 };
 
-export const precedented = <H extends ConsumeHandle, C, R, Ps extends RDParser<H, C & PrecedenceContext, R>[][]>(
+export const precedented = <H extends ConsumeHandle, C, R, Ps extends ParserTable<H, C, R>>(
   handle: H,
   context: C,
   { precedence, rec }: PrecedentedOptions<H, C, R>,

--- a/src/utils/system/parser/precedence.ts
+++ b/src/utils/system/parser/precedence.ts
@@ -61,7 +61,7 @@ export const precedented = <H extends ConsumeHandle, C, R, Ps extends RDParser<H
   { precedence, rec }: PrecedentedOptions<H, C, R>,
   parserTable: Ps
 ): R => {
-  if (precedence < 0 && precedence >= parserTable.length) {
+  if (precedence < 0 || precedence >= parserTable.length) {
     throw new Error(`precedence out of bounds of parserTable (0 .. ${parserTable.length - 1})`);
   }
 


### PR DESCRIPTION
## Summary

There were two issues with the parser:
1. the precedence levels weren't quite right
2. there's an issue with how the `precedented`, `lrec`, and `cached` worked together

This fixes both issues.
1. bump `thunkForce` to a higher precedence level than `function application`
2. update `precedented` to allow custom recursion function, and update `lrec` and `cached` to handle additional arguments to the parser function.

